### PR TITLE
Clean up the function to upload attachments to Zotero

### DIFF
--- a/zotero2remarkable_bridge.py
+++ b/zotero2remarkable_bridge.py
@@ -37,7 +37,7 @@ def pull(zot: Zotero, webdav: bool, read_folder: str):
             if webdav:
                 zotero_upload_webdav(pdf_name, zot, webdav)
             else:
-                zotero_upload(pdf_name, zot)
+                attach_pdf_to_zotero_document(pdf_name, zot)
     else:
         logger.info("No files ")
 


### PR DESCRIPTION
In response to #13, I cleaned up the function that uploads attachments to zotero.

The issue was that the code was performing an early exit. It was also just a big mess all-around which is why the intent was hard to parse from the codeblock in the first place. I refactored the function to better match the intent of the function.

Still need to test it, this is my proposed test scenario:

In Zotero, make sure you have two documents:

- Document A: tagged "synced" + marked "annotated"
- Document B: tagged "synced" + matching the _upload candidate_

Need to verify that

- [ ] The old code fails in this scenario (as long as A is processed before B)
- [ ] The new code _doesn't_ fail regardless of the order of processing