### PR TITLE
WIP: allow for custom root folder on RM

### DIFF
--- a/zotero2remarkable_bridge/config_functions.py
+++ b/zotero2remarkable_bridge/config_functions.py
@@ -7,14 +7,16 @@ from webdav3.client import Client as wdClient
 
 logger = logging.getLogger("zotero_rM_bridge.config")
 
+
 def load_config(config_file):
     with open(config_file, "r") as stream:
         try:
             config_dict = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
             logger.exception(exc)
+
     zot = zotero.Zotero(config_dict["LIBRARY_ID"], config_dict["LIBRARY_TYPE"], config_dict["API_KEY"])
-    folders = {"unread": normalize_rm_path(config_dict["UNREAD_FOLDER"]), "read": normalize_rm_path(config_dict["READ_FOLDER"])}
+    folders = get_folders(config_dict)
     if config_dict["USE_WEBDAV"] == "True":
         webdav_data = {
             "webdav_hostname": config_dict["WEBDAV_HOSTNAME"],
@@ -32,6 +34,7 @@ def write_config(file_name):
     config_data = {}
     input("Couldn't find config file. Let's create one! Press Enter to continue...\n")
     print("On your ReMarkable you should have created a folder called Zotero in the root directory.\nIn the following specify ONLY the names of the subfolders, e. g 'read' instead of 'zotero/read'.\n")
+    # TODO: Ask user for root folder config_data["ROOT-FOLDER"] = input("")
     config_data["UNREAD_FOLDER"] = input("Which ReMarkable folder should files be synced to? ")
     config_data["READ_FOLDER"] = input("Which ReMarkable folder should files be synced from? ")
     print("You can find your library ID on this page")
@@ -56,14 +59,35 @@ def write_config(file_name):
     logger.info(f"Config written to {file_name}\n If something went wrong, please edit config manually.")
 
 
-def normalize_rm_path(folder_name: str) -> str:
+# Default constants. Might be useful for refining the setup process, for ex. opt-in to create default folders on RM.
+DEFAULT_ROOT = "Zotero"
+DEFAULT_READ = "read"
+DEFAULT_UNREAD = "write"
+
+def get_folders(config_dict: dict[str, str]) -> dict[str, str]:
+    """Creates dict of folders. Uses dict.get() function that sets default values if key doesn't exist.
+    Normalizes every path, stripping it of whitespaces and slashes. Subfolders are also stripped of leading 'Zotero/'.
+    TODO: Maybe make this robust against empty entries as well?
+    """
+    root_folder = normalize_path(config_dict.get("ROOT-FOLDER", DEFAULT_ROOT))
+    unread_folder = normalize_rm_path(config_dict.get("UNREAD_FOLDER", DEFAULT_UNREAD))
+    read_folder = normalize_rm_path(config_dict.get("READ_FOLDER", DEFAULT_READ))
+    return{"unread": "/" + root_folder + "/" + unread_folder + "/", "read": "/" + root_folder + "/" + read_folder + "/"}
+
+
+def normalize_rm_path(path: str) -> str:
     """Performs cleanup of folder names, mainly for cases like 'Zotero/read' which should just be 'read'"""
-    match folder_name:        
+    if normalize_path(path).lower().startswith("zotero/"):
+        return path[7:] # removes "zotero/" (case insensitive)
+    else:
+        return normalize_path(path)
+    
+
+def normalize_path(path: str) -> str:
+    match path:        
         case str(s) if s.startswith("/") or s.startswith(" "):
-            return normalize_rm_path(s[1:]) # recursively removes all leading slashes and whitespaces
-        case str(s) if s.endswith(" "):
-            return normalize_rm_path(s[:-1]) # recursively removes trailing whitespace
-        case str(s) if s.lower().startswith("zotero/"):
-            return s[7:] # removes "zotero/" (case insensitive)
+            return normalize_path(s[1:]) # recursively removes all leading slashes and whitespaces
+        case str(s) if s.endswith("/") or s.endswith(" "):
+            return normalize_path(s[:-1]) # recursively removes trailing whitespace
         case _:
-            return folder_name
+            return path

--- a/zotero2remarkable_bridge/sync_functions.py
+++ b/zotero2remarkable_bridge/sync_functions.py
@@ -33,7 +33,7 @@ def sync_to_rm(item, zot, folders):
             zot.dump(attachment_id, path=temp_path)
             file_name = temp_path / attachment_name
             if file_name:
-                if rmapi.upload_file(file_name, f"/Zotero/{folders['unread']}"):
+                if rmapi.upload_file(file_name, folders['unread']):
                     zot.add_tags(item, "synced")
                     os.remove(file_name)
                     logger.info(f"Uploaded {attachment_name} to reMarkable.")
@@ -62,7 +62,7 @@ def sync_to_rm_webdav(item, zot, webdav, folders):
                 zf.extractall(unzip_path)
                 zf.extractall(".")
             if (unzip_path / attachment_name).is_file():
-                uploader = rmapi.upload_file(str(unzip_path / attachment_name), f"/Zotero/{folders['unread']}")
+                uploader = rmapi.upload_file(str(unzip_path / attachment_name), folders['unread'])
             else:
                 """ #TODO: Sometimes Zotero does not seem to rename attachments properly,
                     leading to reported file names diverging from the actual one. 

--- a/zotero2remarkable_bridge/zotero2remarkable_bridge.py
+++ b/zotero2remarkable_bridge/zotero2remarkable_bridge.py
@@ -49,7 +49,7 @@ def main():
         write_config("config.yml")
 
     zot, webdav, folders = load_config("config.yml")
-    read_folder = f"/Zotero/{folders['read']}/"
+    read_folder = folders['read']
     
     try:
         opts, args = getopt.getopt(argv, "m:")


### PR DESCRIPTION
**This is WIP!**

# Core Changes
The `get_folders` function handles everything related to the rm folder paths. It does so by using the .get() function on the provided config_file dictionary. It is guaranteed that this dictionary exists, because `main` calls `write_config` if it doesn't, which in turn will create this dictionary.

## Existing users
This should not cause trouble for existing users:
1. The `.get()` method for dictionaries allows to set default values in case the key does not exist. If `ROOT-FOLDER` does not exist in the config – and for current users it does not – the call `config_dict.get("PARENT-FOLDER", DEFAULT_ROOT)` will return `"Zotero"`.
2. The extractions of read and unread paths are normalized using `normalize_rm_path`, so they will return `read` and `unread` regardless if useres currently have `Zotero/read` or just `read` in their config. Normalization also removes any whitespaces and leading or trailing slashes. The responsiblity of correctly putting together the file path lies soley at `get_folders`. 
## New users
I have NOT made changes to `write_config` yet.
## Benefits
In other parts of the code, instead of `f"/Zotero/{folders['read']}/` we now just can use `folders['read]`. We no longer have `"Zotero`" hard-coded. This allows users to name the root folder however they want.
## Tests
I have tested this change from the perspective of an existing user with an already existing and unchanged config file. It works. Still needs some testing once changes to `write_config` have been implemented.

# Other refactorings
I have split `normalize_rm_path` into two separate functions. One for stripping a string of leading and trailing whitespaces and slashes; one for removing `zotero/` if it's a prefix. The tests still run fine.
